### PR TITLE
Updates results for Balle (2017) and Balle (2018) for both MSE-optimi…

### DIFF
--- a/results/image_compression/README.md
+++ b/results/image_compression/README.md
@@ -25,54 +25,58 @@ evaluation data sets are covered.
 
 ### Learning-based Methods
 
-1.   [Context-adaptive Entropy Model for End-to-end Optimized Image Compression](https://openreview.net/forum?id=HyxKIiAqYQ)\
+1.  [Channel-wise autoregressive entropy models for learned image compression](http://research.minnen.org/papers/minnen-submitted-icip2020-draft.pdf)\
+    David Minnen and Saurabh Singh\
+    Int. Conf. on Image Processing (ICIP) 2020
+
+2.  [Context-adaptive Entropy Model for End-to-end Optimized Image Compression](https://openreview.net/forum?id=HyxKIiAqYQ)\
     Jooyoung Lee, Seunghyun Cho, and Seung-Kwon Beack\
     Int. Conf. on Learning Representations (ICLR) 2019
 
-2.  [Joint autoregressive and hierarchical priors for learned image
+3.  [Joint autoregressive and hierarchical priors for learned image
     compression](https://arxiv.org/abs/1809.02736)\
     David Minnen, Johannes Ballé, and George Toderici\
     Advances in Neural Information Processing Systems (NeurIPS) 2018
 
-3.  [Learning a Code-Space Predictor by Exploiting Intra-Image-Dependencies](http://bmvc2018.org/contents/papers/0491.pdf)\
+4.  [Learning a Code-Space Predictor by Exploiting Intra-Image-Dependencies](http://bmvc2018.org/contents/papers/0491.pdf)\
     Jan P. Klopp, Yu-Chiang Frank Wang, Shao-Yi Chien, and Liang-Gee Chen\
     British Machine Vision Conference (BMVC) 2018
 
-4.  [Variational Image Compression with a Scale Hyperprior](https://arxiv.org/abs/1802.01436)\
+5.  [Variational Image Compression with a Scale Hyperprior](https://arxiv.org/abs/1802.01436)\
     Johannes Ballé, David Minnen, Saurabh Singh, Sung Jin Hwang, and Nick
     Johnston\
     Int. Conf. on Learning Representations (ICLR) 2018
 
-5.  [Image-dependent local entropy models for image compression with deep
+6.  [Image-dependent local entropy models for image compression with deep
     networks](https://arxiv.org/abs/1805.12295)\
     David Minnen, George Toderici, Saurabh Singh, Sung Jin Hwang, and Michele
     Covell\
     Int. Conf. on Image Processing (ICIP) 2018
 
-6.  [Improved Lossy Image Compression With Priming and Spatially Adaptive Bit
+7.  [Improved Lossy Image Compression With Priming and Spatially Adaptive Bit
     Rates for Recurrent Networks](https://arxiv.org/abs/1703.10114)\
     Nick Johnston, Damien Vincent, David Minnen, Michele Covell, Saurabh Singh,
     Troy Chinen, Sung Jin Hwang, Joel Shor, and George Toderici\
     IEEE Conf. on Computer Vision and Pattern Recognition (CVPR) 2018
 
-7.  [Real-Time Adaptive Image Compression](https://arxiv.org/abs/1705.05823)\
+8.  [Real-Time Adaptive Image Compression](https://arxiv.org/abs/1705.05823)\
     Oren Rippel and Lubomir Bourdev\
     International Conference on Machine Learning (ICML) 2017
 
-8.  [End-to-end Optimized Image Compression](https://arxiv.org/abs/1611.01704)\
+9.  [End-to-end Optimized Image Compression](https://arxiv.org/abs/1611.01704)\
     Johannes Ballé, Valero Laparra, and Eero P. Simoncelli\
     Int. Conf. on Learning Representations (ICLR) 2017
 
-9.  [Lossy Image Compression with Compressive Autoencoders](https://openreview.net/forum?id=rJiNwv9gg)\
+10.  [Lossy Image Compression with Compressive Autoencoders](https://openreview.net/forum?id=rJiNwv9gg)\
     Lucas Theis, Wenzhe Shi, Andrew Cunningham, and Ferenc Huszár\
     Int. Conf. on Learning Representations (ICLR) 2017
 
-10. [Spatially adaptive image compression using a tiled deep network](https://arxiv.org/abs/1802.02629)\
+11. [Spatially adaptive image compression using a tiled deep network](https://arxiv.org/abs/1802.02629)\
     David Minnen, George Toderici, Michele Covell, Troy Chinen, Nick Johnston,
     Joel Shor, Sung Jin Hwang, Damien Vincent, and Saurabh Singh\
     Int. Conference on Image Processing (ICIP) 2017
 
-11. [Full Resolution Image Compression with Recurrent Neural Networks](https://arxiv.org/abs/1608.05148)\
+12. [Full Resolution Image Compression with Recurrent Neural Networks](https://arxiv.org/abs/1608.05148)\
     George Toderici, Damien Vincent, Nick Johnston, Sung Jin Hwang, David
     Minnen, Joel Shor, and Michele Covell\
     IEEE Conference on Computer Vision and Pattern Recognition (CVPR) 2017

--- a/results/image_compression/kodak/MS-SSIM_sRGB_RGB/balle-2017-iclr-opt-mse.txt
+++ b/results/image_compression/kodak/MS-SSIM_sRGB_RGB/balle-2017-iclr-opt-mse.txt
@@ -1,0 +1,21 @@
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MSE)" on kodak.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains MS-SSIM/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#  2. We often graph MS-SSIM values in dB for visual clarity using:
+#     ms_ssim_db = -10 * log10(1 - ms_ssim).
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.119752, 0.903700
+0.194591, 0.931041
+0.316000, 0.954783
+0.481060, 0.969139
+0.721303, 0.980815
+1.060841, 0.986755
+1.458681, 0.992090
+1.957564, 0.994965

--- a/results/image_compression/kodak/MS-SSIM_sRGB_RGB/balle-2017-iclr-opt-msssim.txt
+++ b/results/image_compression/kodak/MS-SSIM_sRGB_RGB/balle-2017-iclr-opt-msssim.txt
@@ -1,0 +1,21 @@
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MS-SSIM)" on kodak.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains MS-SSIM/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#  2. We often graph MS-SSIM values in dB for visual clarity using:
+#     ms_ssim_db = -10 * log10(1 - ms_ssim).
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.088965, 0.911371
+0.159174, 0.944562
+0.274751, 0.966757
+0.456740, 0.981293
+0.657944, 0.988021
+1.039564, 0.993110
+1.519391, 0.996033
+2.100730, 0.997772

--- a/results/image_compression/kodak/MS-SSIM_sRGB_RGB/balle-2018-iclr-opt-mse.txt
+++ b/results/image_compression/kodak/MS-SSIM_sRGB_RGB/balle-2018-iclr-opt-mse.txt
@@ -1,6 +1,6 @@
-# Aggregate rate-distortion data for "Ballé 2017 (ICLR)" on tecnick.
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MSE)" on kodak.
 # The first column contains bits per pixel (bpp) values.
-# The second column contains MS-SSIM/sRGB/Y' values.
+# The second column contains MS-SSIM/sRGB/R'G'B' values.
 #
 # Notes:
 #  1. Aggregate values were calculated by averaging over a constant
@@ -11,11 +11,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.115931, 0.948947
-0.174513, 0.963567
-0.261745, 0.975993
-0.380673, 0.982649
-0.550055, 0.988475
-0.793547, 0.991225
-1.111101, 0.994542
-1.547634, 0.996354
+0.115239, 0.907527
+0.185698, 0.936307
+0.301804, 0.958691
+0.468972, 0.972416
+0.686378, 0.982478
+0.966864, 0.988344
+1.307441, 0.992647
+1.727503, 0.995267

--- a/results/image_compression/kodak/MS-SSIM_sRGB_RGB/balle-2018-iclr-opt-msssim.txt
+++ b/results/image_compression/kodak/MS-SSIM_sRGB_RGB/balle-2018-iclr-opt-msssim.txt
@@ -1,0 +1,21 @@
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MS-SSIM)" on kodak.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains MS-SSIM/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#  2. We often graph MS-SSIM values in dB for visual clarity using:
+#     ms_ssim_db = -10 * log10(1 - ms_ssim).
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.092031, 0.923012
+0.166818, 0.953873
+0.281376, 0.972845
+0.398321, 0.981048
+0.650651, 0.989613
+0.996335, 0.994012
+1.377538, 0.996171
+2.030330, 0.998020

--- a/results/image_compression/kodak/MS-SSIM_sRGB_Y/balle-2017-iclr-opt-mse.txt
+++ b/results/image_compression/kodak/MS-SSIM_sRGB_Y/balle-2017-iclr-opt-mse.txt
@@ -1,0 +1,21 @@
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MSE)" on kodak.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains MS-SSIM/sRGB/Y' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#  2. We often graph MS-SSIM values in dB for visual clarity using:
+#     ms_ssim_db = -10 * log10(1 - ms_ssim).
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.119752, 0.912465
+0.194591, 0.938222
+0.316000, 0.960606
+0.481060, 0.973768
+0.721303, 0.984341
+1.060841, 0.989370
+1.458681, 0.994011
+1.957564, 0.996310

--- a/results/image_compression/kodak/MS-SSIM_sRGB_Y/balle-2017-iclr-opt-msssim.txt
+++ b/results/image_compression/kodak/MS-SSIM_sRGB_Y/balle-2017-iclr-opt-msssim.txt
@@ -1,6 +1,6 @@
-# Aggregate rate-distortion data for "Ballé 2017 (ICLR)" on tecnick.
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MS-SSIM)" on kodak.
 # The first column contains bits per pixel (bpp) values.
-# The second column contains MS-SSIM/sRGB/R'G'B' values.
+# The second column contains MS-SSIM/sRGB/Y' values.
 #
 # Notes:
 #  1. Aggregate values were calculated by averaging over a constant
@@ -11,11 +11,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.115931, 0.937430
-0.174513, 0.954175
-0.261745, 0.968157
-0.380673, 0.976136
-0.550055, 0.983301
-0.793547, 0.987275
-1.111101, 0.991833
-1.547634, 0.994729
+0.088965, 0.921848
+0.159174, 0.952119
+0.274751, 0.972189
+0.456740, 0.984918
+0.657944, 0.990717
+1.039564, 0.994777
+1.519391, 0.997142
+2.100730, 0.998423

--- a/results/image_compression/kodak/MS-SSIM_sRGB_Y/balle-2018-iclr-opt-mse.txt
+++ b/results/image_compression/kodak/MS-SSIM_sRGB_Y/balle-2018-iclr-opt-mse.txt
@@ -1,0 +1,21 @@
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MSE)" on kodak.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains MS-SSIM/sRGB/Y' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#  2. We often graph MS-SSIM values in dB for visual clarity using:
+#     ms_ssim_db = -10 * log10(1 - ms_ssim).
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.115239, 0.916089
+0.185698, 0.943538
+0.301804, 0.964504
+0.468972, 0.976787
+0.686378, 0.985790
+0.966864, 0.991048
+1.307441, 0.994607
+1.727503, 0.996637

--- a/results/image_compression/kodak/MS-SSIM_sRGB_Y/balle-2018-iclr-opt-msssim.txt
+++ b/results/image_compression/kodak/MS-SSIM_sRGB_Y/balle-2018-iclr-opt-msssim.txt
@@ -1,4 +1,4 @@
-# Aggregate rate-distortion data for "Ballé 2018 (ICLR)" on tecnick.
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MS-SSIM)" on kodak.
 # The first column contains bits per pixel (bpp) values.
 # The second column contains MS-SSIM/sRGB/Y' values.
 #
@@ -11,11 +11,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.105457, 0.951240
-0.154802, 0.966343
-0.228370, 0.977179
-0.330983, 0.983507
-0.471083, 0.988843
-0.655272, 0.992183
-0.905265, 0.994779
-1.262145, 0.996459
+0.092031, 0.932611
+0.166818, 0.960943
+0.281376, 0.977778
+0.398321, 0.984935
+0.650651, 0.992063
+0.996335, 0.995652
+1.377538, 0.997328
+2.030330, 0.998616

--- a/results/image_compression/kodak/PSNR_sRGB_RGB/balle-2017-iclr-opt-mse.txt
+++ b/results/image_compression/kodak/PSNR_sRGB_RGB/balle-2017-iclr-opt-mse.txt
@@ -1,4 +1,4 @@
-# Aggregate rate-distortion data for "Ballé 2017 (ICLR)" on tecnick.
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MSE)" on kodak.
 # The first column contains bits per pixel (bpp) values.
 # The second column contains PSNR/sRGB/R'G'B' values.
 #
@@ -9,11 +9,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.115931, 28.814958
-0.174513, 30.453974
-0.261745, 32.072275
-0.380673, 33.618755
-0.550055, 35.302337
-0.793547, 36.988602
-1.111101, 38.836650
-1.547634, 40.635048
+0.119752, 26.775134
+0.194591, 28.348719
+0.316000, 30.020793
+0.481060, 31.729556
+0.721303, 33.685797
+1.060841, 35.815864
+1.458681, 38.019954
+1.957564, 40.133996

--- a/results/image_compression/kodak/PSNR_sRGB_RGB/balle-2017-iclr-opt-msssim.txt
+++ b/results/image_compression/kodak/PSNR_sRGB_RGB/balle-2017-iclr-opt-msssim.txt
@@ -1,0 +1,19 @@
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MS-SSIM)" on kodak.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains PSNR/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.088965, 24.443779
+0.159174, 25.961468
+0.274751, 27.258965
+0.456740, 28.997272
+0.657944, 30.013783
+1.039564, 32.090088
+1.519391, 33.892938
+2.100730, 35.333526

--- a/results/image_compression/kodak/PSNR_sRGB_RGB/balle-2018-iclr-opt-mse.txt
+++ b/results/image_compression/kodak/PSNR_sRGB_RGB/balle-2018-iclr-opt-mse.txt
@@ -1,0 +1,19 @@
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MSE)" on kodak.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains PSNR/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.115239, 27.106351
+0.185698, 28.679134
+0.301804, 30.616753
+0.468972, 32.554935
+0.686378, 34.580960
+0.966864, 36.720366
+1.307441, 38.807960
+1.727503, 40.794920

--- a/results/image_compression/kodak/PSNR_sRGB_RGB/balle-2018-iclr-opt-msssim.txt
+++ b/results/image_compression/kodak/PSNR_sRGB_RGB/balle-2018-iclr-opt-msssim.txt
@@ -1,0 +1,19 @@
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MS-SSIM)" on kodak.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains PSNR/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.092031, 24.725623
+0.166818, 26.331231
+0.281376, 27.836886
+0.398321, 28.710904
+0.650651, 30.425433
+0.996335, 32.462500
+1.377538, 33.546850
+2.030330, 35.394737

--- a/results/image_compression/kodak/PSNR_sRGB_RGB/lee-2019-context-adaptive.txt
+++ b/results/image_compression/kodak/PSNR_sRGB_RGB/lee-2019-context-adaptive.txt
@@ -1,0 +1,20 @@
+# Aggregate rate-distortion data for "Lee 2019 (ICLR)" on kodak.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains PSNR/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.102128, 27.635956
+0.147518, 28.801123
+0.204255, 29.889887
+0.299291, 31.265169
+0.436879, 32.831459
+0.692199, 35.161797
+0.995745, 37.301125
+1.272340, 38.924721
+1.592908, 40.357304

--- a/results/image_compression/kodak/PSNR_sRGB_RGB/minnen-2020-icip.txt
+++ b/results/image_compression/kodak/PSNR_sRGB_RGB/minnen-2020-icip.txt
@@ -1,4 +1,4 @@
-# Aggregate rate-distortion data for "Ballé 2018 (ICLR)" on tecnick.
+# Aggregate rate-distortion data for "Minnen 2020 (ICIP)" on kodak.
 # The first column contains bits per pixel (bpp) values.
 # The second column contains PSNR/sRGB/R'G'B' values.
 #
@@ -9,11 +9,13 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.105457, 29.234396
-0.154802, 30.862438
-0.228370, 32.571271
-0.330983, 34.146224
-0.471083, 35.867773
-0.655272, 37.420290
-0.905265, 39.192136
-1.262145, 40.975431
+0.112942, 28.609292
+0.189197, 30.246944
+0.299300, 31.948906
+0.459559, 33.802145
+0.668633, 35.756475
+0.941531, 37.712819
+1.279007, 39.608699
+1.704720, 41.445196
+2.302723, 43.649106
+3.018105, 45.644330

--- a/results/image_compression/kodak/PSNR_sRGB_Y/balle-2017-iclr-opt-mse.txt
+++ b/results/image_compression/kodak/PSNR_sRGB_Y/balle-2017-iclr-opt-mse.txt
@@ -1,4 +1,4 @@
-# Aggregate rate-distortion data for "Ballé 2017 (ICLR)" on tecnick.
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MSE)" on kodak.
 # The first column contains bits per pixel (bpp) values.
 # The second column contains PSNR/sRGB/Y' values.
 #
@@ -9,11 +9,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.115931, 29.729756
-0.174513, 31.382661
-0.261745, 33.087073
-0.380673, 34.724334
-0.550055, 36.551650
-0.793547, 38.382768
-1.111101, 40.405371
-1.547634, 42.341405
+0.119752, 27.121149
+0.194591, 28.713727
+0.316000, 30.431627
+0.481060, 32.190087
+0.721303, 34.241010
+1.060841, 36.496619
+1.458681, 38.906598
+1.957564, 41.240205

--- a/results/image_compression/kodak/PSNR_sRGB_Y/balle-2017-iclr-opt-msssim.txt
+++ b/results/image_compression/kodak/PSNR_sRGB_Y/balle-2017-iclr-opt-msssim.txt
@@ -1,4 +1,4 @@
-# Aggregate rate-distortion data for "Minnen 2020 (ICIP)" on kodak.
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MS-SSIM)" on kodak.
 # The first column contains bits per pixel (bpp) values.
 # The second column contains PSNR/sRGB/Y' values.
 #
@@ -9,13 +9,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.112942, 28.929526
-0.189197, 30.615043
-0.299300, 32.377681
-0.459559, 34.332430
-0.668633, 36.410187
-0.941531, 38.535650
-1.279007, 40.635977
-1.704720, 42.738868
-2.302723, 45.135623
-3.018105, 47.452751
+0.088965, 24.943757
+0.159174, 26.331073
+0.274751, 27.551279
+0.456740, 29.300307
+0.657944, 30.306492
+1.039564, 32.420533
+1.519391, 34.220280
+2.100730, 35.662792

--- a/results/image_compression/kodak/PSNR_sRGB_Y/balle-2018-iclr-opt-mse.txt
+++ b/results/image_compression/kodak/PSNR_sRGB_Y/balle-2018-iclr-opt-mse.txt
@@ -1,4 +1,4 @@
-# Aggregate rate-distortion data for "Minnen 2020 (ICIP)" on kodak.
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MSE)" on kodak.
 # The first column contains bits per pixel (bpp) values.
 # The second column contains PSNR/sRGB/Y' values.
 #
@@ -9,13 +9,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.112942, 28.929526
-0.189197, 30.615043
-0.299300, 32.377681
-0.459559, 34.332430
-0.668633, 36.410187
-0.941531, 38.535650
-1.279007, 40.635977
-1.704720, 42.738868
-2.302723, 45.135623
-3.018105, 47.452751
+0.115239, 27.504627
+0.185698, 29.082609
+0.301804, 31.061476
+0.468972, 33.074653
+0.686378, 35.214096
+0.966864, 37.518340
+1.307441, 39.815185
+1.727503, 42.034352

--- a/results/image_compression/kodak/PSNR_sRGB_Y/balle-2018-iclr-opt-msssim.txt
+++ b/results/image_compression/kodak/PSNR_sRGB_Y/balle-2018-iclr-opt-msssim.txt
@@ -1,4 +1,4 @@
-# Aggregate rate-distortion data for "Minnen 2020 (ICIP)" on kodak.
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MS-SSIM)" on kodak.
 # The first column contains bits per pixel (bpp) values.
 # The second column contains PSNR/sRGB/Y' values.
 #
@@ -9,13 +9,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.112942, 28.929526
-0.189197, 30.615043
-0.299300, 32.377681
-0.459559, 34.332430
-0.668633, 36.410187
-0.941531, 38.535650
-1.279007, 40.635977
-1.704720, 42.738868
-2.302723, 45.135623
-3.018105, 47.452751
+0.092031, 25.245428
+0.166818, 26.737111
+0.281376, 28.156662
+0.398321, 28.989463
+0.650651, 30.699881
+0.996335, 32.787665
+1.377538, 33.888382
+2.030330, 35.765154

--- a/results/image_compression/tecnick/MS-SSIM_sRGB_RGB/balle-2017-iclr-opt-mse.txt
+++ b/results/image_compression/tecnick/MS-SSIM_sRGB_RGB/balle-2017-iclr-opt-mse.txt
@@ -1,0 +1,21 @@
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MSE)" on tecnick.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains MS-SSIM/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#  2. We often graph MS-SSIM values in dB for visual clarity using:
+#     ms_ssim_db = -10 * log10(1 - ms_ssim).
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.115931, 0.937430
+0.174513, 0.954175
+0.261745, 0.968157
+0.380673, 0.976136
+0.550055, 0.983301
+0.793547, 0.987275
+1.111101, 0.991833
+1.547634, 0.994729

--- a/results/image_compression/tecnick/MS-SSIM_sRGB_RGB/balle-2017-iclr-opt-msssim.txt
+++ b/results/image_compression/tecnick/MS-SSIM_sRGB_RGB/balle-2017-iclr-opt-msssim.txt
@@ -1,0 +1,21 @@
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MS-SSIM)" on tecnick.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains MS-SSIM/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#  2. We often graph MS-SSIM values in dB for visual clarity using:
+#     ms_ssim_db = -10 * log10(1 - ms_ssim).
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.087993, 0.940364
+0.143978, 0.961145
+0.230788, 0.974824
+0.366453, 0.984012
+0.541671, 0.989719
+0.835715, 0.993990
+1.255564, 0.997091
+1.806730, 0.998794

--- a/results/image_compression/tecnick/MS-SSIM_sRGB_RGB/balle-2018-iclr-opt-mse.txt
+++ b/results/image_compression/tecnick/MS-SSIM_sRGB_RGB/balle-2018-iclr-opt-mse.txt
@@ -1,0 +1,21 @@
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MSE)" on tecnick.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains MS-SSIM/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#  2. We often graph MS-SSIM values in dB for visual clarity using:
+#     ms_ssim_db = -10 * log10(1 - ms_ssim).
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.105457, 0.940467
+0.154802, 0.957177
+0.228370, 0.969590
+0.330983, 0.977247
+0.471083, 0.983751
+0.655272, 0.988089
+0.905265, 0.991795
+1.262145, 0.994664

--- a/results/image_compression/tecnick/MS-SSIM_sRGB_RGB/balle-2018-iclr-opt-msssim.txt
+++ b/results/image_compression/tecnick/MS-SSIM_sRGB_RGB/balle-2018-iclr-opt-msssim.txt
@@ -1,0 +1,21 @@
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MS-SSIM)" on tecnick.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains MS-SSIM/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#  2. We often graph MS-SSIM values in dB for visual clarity using:
+#     ms_ssim_db = -10 * log10(1 - ms_ssim).
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.084147, 0.947396
+0.136033, 0.966016
+0.213825, 0.977739
+0.310643, 0.984355
+0.491282, 0.990337
+0.748023, 0.994525
+1.094067, 0.997132
+1.659701, 0.998906

--- a/results/image_compression/tecnick/MS-SSIM_sRGB_Y/balle-2017-iclr-opt-mse.txt
+++ b/results/image_compression/tecnick/MS-SSIM_sRGB_Y/balle-2017-iclr-opt-mse.txt
@@ -1,6 +1,6 @@
-# Aggregate rate-distortion data for "Ballé 2018 (ICLR)" on tecnick.
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MSE)" on tecnick.
 # The first column contains bits per pixel (bpp) values.
-# The second column contains MS-SSIM/sRGB/R'G'B' values.
+# The second column contains MS-SSIM/sRGB/Y' values.
 #
 # Notes:
 #  1. Aggregate values were calculated by averaging over a constant
@@ -11,11 +11,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.105457, 0.940467
-0.154802, 0.957177
-0.228370, 0.969590
-0.330983, 0.977247
-0.471083, 0.983751
-0.655272, 0.988089
-0.905265, 0.991795
-1.262145, 0.994664
+0.115931, 0.948947
+0.174513, 0.963567
+0.261745, 0.975993
+0.380673, 0.982649
+0.550055, 0.988475
+0.793547, 0.991225
+1.111101, 0.994542
+1.547634, 0.996354

--- a/results/image_compression/tecnick/MS-SSIM_sRGB_Y/balle-2017-iclr-opt-msssim.txt
+++ b/results/image_compression/tecnick/MS-SSIM_sRGB_Y/balle-2017-iclr-opt-msssim.txt
@@ -1,0 +1,21 @@
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MS-SSIM)" on tecnick.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains MS-SSIM/sRGB/Y' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#  2. We often graph MS-SSIM values in dB for visual clarity using:
+#     ms_ssim_db = -10 * log10(1 - ms_ssim).
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.087993, 0.952371
+0.143978, 0.970455
+0.230788, 0.981901
+0.366453, 0.989047
+0.541671, 0.993068
+0.835715, 0.995640
+1.255564, 0.997456
+1.806730, 0.998554

--- a/results/image_compression/tecnick/MS-SSIM_sRGB_Y/balle-2018-iclr-opt-mse.txt
+++ b/results/image_compression/tecnick/MS-SSIM_sRGB_Y/balle-2018-iclr-opt-mse.txt
@@ -1,0 +1,21 @@
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MSE)" on tecnick.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains MS-SSIM/sRGB/Y' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#  2. We often graph MS-SSIM values in dB for visual clarity using:
+#     ms_ssim_db = -10 * log10(1 - ms_ssim).
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.105457, 0.951240
+0.154802, 0.966343
+0.228370, 0.977179
+0.330983, 0.983507
+0.471083, 0.988843
+0.655272, 0.992183
+0.905265, 0.994779
+1.262145, 0.996459

--- a/results/image_compression/tecnick/MS-SSIM_sRGB_Y/balle-2018-iclr-opt-msssim.txt
+++ b/results/image_compression/tecnick/MS-SSIM_sRGB_Y/balle-2018-iclr-opt-msssim.txt
@@ -1,0 +1,21 @@
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MS-SSIM)" on tecnick.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains MS-SSIM/sRGB/Y' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#  2. We often graph MS-SSIM values in dB for visual clarity using:
+#     ms_ssim_db = -10 * log10(1 - ms_ssim).
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.084147, 0.958534
+0.136033, 0.974825
+0.213825, 0.984461
+0.310643, 0.989543
+0.491282, 0.993589
+0.748023, 0.996073
+1.094067, 0.997538
+1.659701, 0.998623

--- a/results/image_compression/tecnick/PSNR_sRGB_RGB/balle-2017-iclr-opt-mse.txt
+++ b/results/image_compression/tecnick/PSNR_sRGB_RGB/balle-2017-iclr-opt-mse.txt
@@ -1,0 +1,19 @@
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MSE)" on tecnick.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains PSNR/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.115931, 28.814958
+0.174513, 30.453974
+0.261745, 32.072275
+0.380673, 33.618755
+0.550055, 35.302337
+0.793547, 36.988602
+1.111101, 38.836650
+1.547634, 40.635048

--- a/results/image_compression/tecnick/PSNR_sRGB_RGB/balle-2017-iclr-opt-msssim.txt
+++ b/results/image_compression/tecnick/PSNR_sRGB_RGB/balle-2017-iclr-opt-msssim.txt
@@ -1,0 +1,19 @@
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MS-SSIM)" on tecnick.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains PSNR/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.087993, 25.942792
+0.143978, 28.362603
+0.230788, 30.422225
+0.366453, 32.402554
+0.541671, 34.032366
+0.835715, 36.012969
+1.255564, 37.963265
+1.806730, 40.005558

--- a/results/image_compression/tecnick/PSNR_sRGB_RGB/balle-2018-iclr-opt-mse.txt
+++ b/results/image_compression/tecnick/PSNR_sRGB_RGB/balle-2018-iclr-opt-mse.txt
@@ -1,0 +1,19 @@
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MSE)" on tecnick.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains PSNR/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.105457, 29.234396
+0.154802, 30.862438
+0.228370, 32.571271
+0.330983, 34.146224
+0.471083, 35.867773
+0.655272, 37.420290
+0.905265, 39.192136
+1.262145, 40.975431

--- a/results/image_compression/tecnick/PSNR_sRGB_RGB/balle-2018-iclr-opt-msssim.txt
+++ b/results/image_compression/tecnick/PSNR_sRGB_RGB/balle-2018-iclr-opt-msssim.txt
@@ -1,0 +1,19 @@
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MS-SSIM)" on tecnick.
+# The first column contains bits per pixel (bpp) values.
+# The second column contains PSNR/sRGB/R'G'B' values.
+#
+# Notes:
+#  1. Aggregate values were calculated by averaging over a constant
+#     lambda value.
+#
+# If you have questions or corrections, please contact:
+#  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
+
+0.084147, 26.761386
+0.136033, 29.009099
+0.213825, 31.078285
+0.310643, 32.614011
+0.491282, 34.598202
+0.748023, 36.514694
+1.094067, 38.140798
+1.659701, 40.371750

--- a/results/image_compression/tecnick/PSNR_sRGB_RGB/minnen-2020-icip.txt
+++ b/results/image_compression/tecnick/PSNR_sRGB_RGB/minnen-2020-icip.txt
@@ -1,6 +1,6 @@
 # Aggregate rate-distortion data for "Minnen 2020 (ICIP)" on tecnick.
 # The first column contains bits per pixel (bpp) values.
-# The second column contains PSNR/sRGB/Y' values.
+# The second column contains PSNR/sRGB/R'G'B' values.
 #
 # Notes:
 #  1. Aggregate values were calculated by averaging over a constant
@@ -9,13 +9,13 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.096514, 31.628286
-0.148632, 33.265607
-0.222172, 34.920533
-0.329241, 36.627327
-0.468026, 38.325688
-0.660635, 40.057978
-0.917032, 41.765257
-1.285604, 43.542740
-1.886344, 45.772857
-2.613850, 47.924666
+0.096514, 30.768091
+0.148632, 32.286996
+0.222172, 33.836108
+0.329241, 35.420478
+0.468026, 36.990152
+0.660635, 38.564633
+0.917032, 40.131405
+1.285604, 41.741072
+1.886344, 43.937265
+2.613850, 45.914066

--- a/results/image_compression/tecnick/PSNR_sRGB_Y/balle-2017-iclr-opt-mse.txt
+++ b/results/image_compression/tecnick/PSNR_sRGB_Y/balle-2017-iclr-opt-mse.txt
@@ -1,4 +1,4 @@
-# Aggregate rate-distortion data for "Minnen 2020 (ICIP)" on kodak.
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MSE)" on tecnick.
 # The first column contains bits per pixel (bpp) values.
 # The second column contains PSNR/sRGB/Y' values.
 #
@@ -9,13 +9,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.112942, 28.929526
-0.189197, 30.615043
-0.299300, 32.377681
-0.459559, 34.332430
-0.668633, 36.410187
-0.941531, 38.535650
-1.279007, 40.635977
-1.704720, 42.738868
-2.302723, 45.135623
-3.018105, 47.452751
+0.115931, 29.729756
+0.174513, 31.382661
+0.261745, 33.087073
+0.380673, 34.724334
+0.550055, 36.551650
+0.793547, 38.382768
+1.111101, 40.405371
+1.547634, 42.341405

--- a/results/image_compression/tecnick/PSNR_sRGB_Y/balle-2017-iclr-opt-msssim.txt
+++ b/results/image_compression/tecnick/PSNR_sRGB_Y/balle-2017-iclr-opt-msssim.txt
@@ -1,4 +1,4 @@
-# Aggregate rate-distortion data for "Ballé 2018 (ICLR)" on tecnick.
+# Aggregate rate-distortion data for "Ballé 2017 (ICLR, opt. MS-SSIM)" on tecnick.
 # The first column contains bits per pixel (bpp) values.
 # The second column contains PSNR/sRGB/Y' values.
 #
@@ -9,11 +9,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.105457, 30.155857
-0.154802, 31.849943
-0.228370, 33.628255
-0.330983, 35.302455
-0.471083, 37.204157
-0.655272, 38.907667
-0.905265, 40.880235
-1.262145, 42.772581
+0.087993, 27.738999
+0.143978, 29.607432
+0.230788, 31.525699
+0.366453, 33.474251
+0.541671, 35.125768
+0.835715, 37.098851
+1.255564, 39.168705
+1.806730, 41.328468

--- a/results/image_compression/tecnick/PSNR_sRGB_Y/balle-2018-iclr-opt-mse.txt
+++ b/results/image_compression/tecnick/PSNR_sRGB_Y/balle-2018-iclr-opt-mse.txt
@@ -1,4 +1,4 @@
-# Aggregate rate-distortion data for "Minnen 2020 (ICIP)" on kodak.
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MSE)" on tecnick.
 # The first column contains bits per pixel (bpp) values.
 # The second column contains PSNR/sRGB/Y' values.
 #
@@ -9,13 +9,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.112942, 28.929526
-0.189197, 30.615043
-0.299300, 32.377681
-0.459559, 34.332430
-0.668633, 36.410187
-0.941531, 38.535650
-1.279007, 40.635977
-1.704720, 42.738868
-2.302723, 45.135623
-3.018105, 47.452751
+0.105457, 30.155857
+0.154802, 31.849943
+0.228370, 33.628255
+0.330983, 35.302455
+0.471083, 37.204157
+0.655272, 38.907667
+0.905265, 40.880235
+1.262145, 42.772581

--- a/results/image_compression/tecnick/PSNR_sRGB_Y/balle-2018-iclr-opt-msssim.txt
+++ b/results/image_compression/tecnick/PSNR_sRGB_Y/balle-2018-iclr-opt-msssim.txt
@@ -1,4 +1,4 @@
-# Aggregate rate-distortion data for "Minnen 2020 (ICIP)" on kodak.
+# Aggregate rate-distortion data for "Ballé 2018 (ICLR, opt. MS-SSIM)" on tecnick.
 # The first column contains bits per pixel (bpp) values.
 # The second column contains PSNR/sRGB/Y' values.
 #
@@ -9,13 +9,11 @@
 # If you have questions or corrections, please contact:
 #  David Minnen (dminnen@google.com) or George Toderici (gtoderici@google.com).
 
-0.112942, 28.929526
-0.189197, 30.615043
-0.299300, 32.377681
-0.459559, 34.332430
-0.668633, 36.410187
-0.941531, 38.535650
-1.279007, 40.635977
-1.704720, 42.738868
-2.302723, 45.135623
-3.018105, 47.452751
+0.084147, 28.323724
+0.136033, 30.258354
+0.213825, 32.146528
+0.310643, 33.666585
+0.491282, 35.673115
+0.748023, 37.665572
+1.094067, 39.375885
+1.659701, 41.717402


### PR DESCRIPTION
…zed and MS-SSIM-optimized models (previously, all results were from the MSE-optimized model). This CL also adds PSNR results for Minnen (2020).

PiperOrigin-RevId: 312196405
Change-Id: Idc59c21fe1798c1fe3da7f03f20cfef12b6772d5